### PR TITLE
feat: add custom getters API with enabled filter and language extras

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,6 +132,59 @@ prompts = {
 
 Available variables: `{buffers}`, `{file}`, `{position}`, `{line}`, `{selection}`, `{diagnostics}`, `{diagnostics_all}`, `{quickfix}`, `{function}`, `{class}`, `{this}`
 
+## Custom Getters
+
+Add custom context items:
+
+```lua
+require("context").setup({
+  getters = {
+    -- Shorthand: just a function
+    my_getter = function(builtin)
+      return "File: " .. (builtin.file() or "none")
+    end,
+
+    -- Full form: with description and filetype filter
+    lua_module = {
+      desc = "Lua module path",
+      enabled = function() return vim.bo.filetype == "lua" end,
+      get = function(builtin)
+        local file = builtin.file()
+        if not file then return nil end
+        return file:gsub("^@", ""):gsub("%.lua$", ""):gsub("/", ".")
+      end,
+    },
+  },
+})
+```
+
+- `builtin` parameter provides access to all built-in getters for composition
+- `enabled` function controls visibility in picker (hidden when returns `false`)
+
+### Extras
+
+Pre-built language-specific getters are available in `context.extras`. Each extra includes an `enabled` function that filters by filetype:
+
+| Name | Description | Example Output |
+|------|-------------|----------------|
+| `python_path` | Python module path | `src.module.ClassName` |
+| `rust_path` | Rust module path | `crate::module::Item` |
+
+Usage:
+
+```lua
+local context = require("context")
+local extras = require("context.extras")
+
+context.setup({
+  picker = context.pickers.snacks,
+  getters = {
+    python_path = extras.python_path,
+    rust_path = extras.rust_path,
+  },
+})
+```
+
 ## Custom Picker
 
 Implement a custom picker with this signature:

--- a/lua/context/config.lua
+++ b/lua/context/config.lua
@@ -8,6 +8,7 @@ M.defaults = {
 	end,
 	picker = nil,
 	prompts = {},
+	getters = {},
 	position_prefix = true,
 }
 

--- a/lua/context/extras.lua
+++ b/lua/context/extras.lua
@@ -1,0 +1,83 @@
+-- luacheck: globals vim
+
+local M = {}
+
+local function extract_name(treesitter_output)
+	if not treesitter_output then
+		return nil
+	end
+	return treesitter_output:match("^%S+%s+(%S+)")
+end
+
+local function extract_file(treesitter_output)
+	if not treesitter_output then
+		return nil
+	end
+	return treesitter_output:match("@([^:]+)")
+end
+
+local function ft_is(...)
+	local targets = { ... }
+	return function()
+		local ft = vim.bo.filetype
+		for _, t in ipairs(targets) do
+			if ft == t then
+				return true
+			end
+		end
+		return false
+	end
+end
+
+M.python_path = {
+	desc = "Python module path (e.g. src.module.ClassName)",
+	enabled = ft_is("python"),
+	get = function(builtin)
+		local class = builtin.class()
+		local func = builtin["function"]()
+		local file = builtin.file()
+
+		local source_file = extract_file(class) or extract_file(func) or file
+		if not source_file then
+			return nil
+		end
+
+		local module = source_file:gsub("^@", ""):gsub("%.py$", ""):gsub("/", ".")
+
+		local name = extract_name(class) or extract_name(func)
+		if name then
+			return module .. "." .. name
+		end
+		return module
+	end,
+}
+
+M.rust_path = {
+	desc = "Rust module path (e.g. crate::module::Item)",
+	enabled = ft_is("rust"),
+	get = function(builtin)
+		local class = builtin.class()
+		local func = builtin["function"]()
+		local file = builtin.file()
+
+		local source_file = extract_file(class) or extract_file(func) or file
+		if not source_file then
+			return nil
+		end
+
+		local module = source_file
+			:gsub("^@", "")
+			:gsub("%.rs$", "")
+			:gsub("/mod$", "")
+			:gsub("^src/", "crate::")
+			:gsub("/", "::")
+
+		local name = extract_name(class) or extract_name(func)
+		if name then
+			return module .. "::" .. name
+		end
+		return module
+	end,
+}
+
+return M


### PR DESCRIPTION
- Add getters config option for user-defined context items
- Support shorthand (function) and full form (desc, enabled, get)
- Add enabled() filter for filetype-specific visibility
- Add context.extras module with python_path and rust_path getters
- Update README with custom getters and extras documentation