### PR TITLE
feat: add lazy evaluation for LSP getters

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,6 +89,12 @@ require("context").setup({
   -- path_prefix = "@",   -- "@src/file.lua"
   -- path_prefix = nil,   -- "src/file.lua"
   path_prefix = "@",
+
+  -- LSP settings for definition getter
+  lsp = {
+    enabled = false,  -- set to true to enable LSP-based getters
+    timeout = 1000,   -- request timeout in ms
+  },
 })
 ```
 
@@ -161,12 +167,16 @@ require("context").setup({
 
 ### Extras
 
-Pre-built language-specific getters are available in `context.extras`. Each extra includes an `enabled` function that filters by filetype:
+Pre-built LSP-based getters are available in `context.extras.lsp`:
 
 | Name | Description | Example Output |
 |------|-------------|----------------|
-| `python_path` | Python module path | `src.module.ClassName` |
-| `rust_path` | Rust module path | `crate::module::Item` |
+| `lsp.definition` | Path to symbol definition via LSP | `@src/module.py:42` |
+| `lsp.references` | All references to symbol via LSP | `@src/main.py:10`<br>`@src/utils.py:25` |
+
+LSP getters are lazy-evaluated on selection to avoid blocking the picker.
+
+Requires an LSP server (e.g., pyright, rust-analyzer). Set `lsp.enabled = true` to use.
 
 Usage:
 
@@ -176,9 +186,10 @@ local extras = require("context.extras")
 
 context.setup({
   picker = context.pickers.snacks,
+  lsp = { enabled = true },
   getters = {
-    python_path = extras.python_path,
-    rust_path = extras.rust_path,
+    definition = extras.lsp.definition,
+    references = extras.lsp.references,
   },
 })
 ```

--- a/lua/context/config.lua
+++ b/lua/context/config.lua
@@ -10,6 +10,10 @@ M.defaults = {
 	prompts = {},
 	getters = {},
 	path_prefix = "@",
+	lsp = {
+		enabled = false,
+		timeout = 1000,
+	},
 }
 
 M.options = vim.deepcopy(M.defaults)

--- a/lua/context/extras.lua
+++ b/lua/context/extras.lua
@@ -1,82 +1,109 @@
 -- luacheck: globals vim
 
+local config = require("context.config")
+
 local M = {}
 
-local function extract_name(treesitter_output)
-	if not treesitter_output then
-		return nil
+M.lsp = {}
+
+local function get_position_encoding()
+	local clients = vim.lsp.get_clients({ bufnr = 0 })
+	if clients[1] then
+		return clients[1].offset_encoding or "utf-16"
 	end
-	return treesitter_output:match("^%S+%s+(%S+)")
+	return "utf-16"
 end
 
-local function extract_file(treesitter_output)
-	if not treesitter_output then
+local function get_lsp_definition_location(transform_fn)
+	local timeout = config.options.lsp.timeout
+	local params = vim.lsp.util.make_position_params(0, get_position_encoding())
+	local results = vim.lsp.buf_request_sync(0, "textDocument/definition", params, timeout)
+
+	if not results then
 		return nil
 	end
-	return treesitter_output:match("@([^:]+)")
-end
 
-local function ft_is(...)
-	local targets = { ... }
-	return function()
-		local ft = vim.bo.filetype
-		for _, t in ipairs(targets) do
-			if ft == t then
-				return true
+	for _, res in pairs(results) do
+		local result = res.result
+		if result and result[1] then
+			local loc = result[1]
+			local uri = loc.uri or loc.targetUri
+			local range = loc.range or loc.targetSelectionRange
+			if uri then
+				local filepath = vim.uri_to_fname(uri)
+				local symbol = vim.fn.expand("<cword>")
+				local line = range and (range.start.line + 1) or nil
+				return transform_fn(filepath, symbol, line)
 			end
 		end
-		return false
 	end
+	return nil
 end
 
-M.python_path = {
-	desc = "Python module path (e.g. src.module.ClassName)",
-	enabled = ft_is("python"),
-	get = function(builtin)
-		local class = builtin.class()
-		local func = builtin["function"]()
-		local file = builtin.file()
-
-		local source_file = extract_file(class) or extract_file(func) or file
-		if not source_file then
-			return nil
-		end
-
-		local module = source_file:gsub("^@", ""):gsub("%.py$", ""):gsub("/", ".")
-
-		local name = extract_name(class) or extract_name(func)
-		if name then
-			return module .. "." .. name
-		end
-		return module
+M.lsp.definition = {
+	desc = "Path to symbol definition via LSP",
+	lazy = true,
+	enabled = function()
+		return config.options.lsp.enabled
+	end,
+	get = function()
+		return get_lsp_definition_location(function(filepath, _, line)
+			local rel_path = vim.fn.fnamemodify(filepath, ":.")
+			local prefix = config.options.path_prefix or ""
+			local result = prefix .. rel_path
+			if line then
+				result = result .. ":" .. line
+			end
+			return result
+		end)
 	end,
 }
 
-M.rust_path = {
-	desc = "Rust module path (e.g. crate::module::Item)",
-	enabled = ft_is("rust"),
-	get = function(builtin)
-		local class = builtin.class()
-		local func = builtin["function"]()
-		local file = builtin.file()
+local function get_lsp_locations(method, params_modifier)
+	local timeout = config.options.lsp.timeout
+	local params = vim.lsp.util.make_position_params(0, get_position_encoding())
+	if params_modifier then
+		params_modifier(params)
+	end
+	local results = vim.lsp.buf_request_sync(0, method, params, timeout)
 
-		local source_file = extract_file(class) or extract_file(func) or file
-		if not source_file then
-			return nil
+	if not results then
+		return nil
+	end
+
+	local prefix = config.options.path_prefix or ""
+	local locations = {}
+	for _, res in pairs(results) do
+		if res.result then
+			for _, loc in ipairs(res.result) do
+				local uri = loc.uri
+				local range = loc.range
+				if uri and range then
+					local filepath = vim.uri_to_fname(uri)
+					local rel_path = vim.fn.fnamemodify(filepath, ":.")
+					local line = range.start.line + 1
+					table.insert(locations, prefix .. rel_path .. ":" .. line)
+				end
+			end
 		end
+	end
 
-		local module = source_file
-			:gsub("^@", "")
-			:gsub("%.rs$", "")
-			:gsub("/mod$", "")
-			:gsub("^src/", "crate::")
-			:gsub("/", "::")
+	if #locations == 0 then
+		return nil
+	end
+	return table.concat(locations, "\n")
+end
 
-		local name = extract_name(class) or extract_name(func)
-		if name then
-			return module .. "::" .. name
-		end
-		return module
+M.lsp.references = {
+	desc = "All references to symbol via LSP",
+	lazy = true,
+	enabled = function()
+		return config.options.lsp.enabled
+	end,
+	get = function()
+		return get_lsp_locations("textDocument/references", function(params)
+			params.context = { includeDeclaration = false }
+		end)
 	end,
 }
 

--- a/lua/context/init.lua
+++ b/lua/context/init.lua
@@ -35,12 +35,23 @@ function M.get_items()
 	for _, ctx in ipairs(getters.items) do
 		local enabled = ctx.enabled
 		if enabled == nil or enabled() then
-			local value = ctx.get()
-			table.insert(items, {
-				name = ctx.name,
-				desc = ctx.desc,
-				value = value,
-			})
+			if ctx.lazy then
+				-- Lazy items: defer evaluation until selection
+				table.insert(items, {
+					name = ctx.name,
+					desc = ctx.desc,
+					value = nil,
+					lazy = true,
+					get = ctx.get,
+				})
+			else
+				local value = ctx.get()
+				table.insert(items, {
+					name = ctx.name,
+					desc = ctx.desc,
+					value = value,
+				})
+			end
 		end
 	end
 
@@ -50,7 +61,22 @@ end
 function M.pick(on_select)
 	local items = M.get_items()
 	local picker = config.options.picker or pickers.snacks
-	picker(items, on_select or config.options.on_select)
+	local callback = on_select or config.options.on_select
+
+	-- Wrap callback to handle lazy evaluation
+	local wrapped_callback = function(item)
+		if item.lazy and item.get and not item.value then
+			local value = item.get(getters.by_name)
+			if value then
+				item.value = value
+				callback(item)
+			end
+		elseif item.value then
+			callback(item)
+		end
+	end
+
+	picker(items, wrapped_callback)
 end
 
 local function register_custom_getters(custom_getters)
@@ -58,13 +84,20 @@ local function register_custom_getters(custom_getters)
 		local fn = type(getter) == "function" and getter or getter.get
 		local desc = type(getter) == "table" and getter.desc or ("Custom: " .. name)
 		local enabled = type(getter) == "table" and getter.enabled or nil
+		local lazy = type(getter) == "table" and getter.lazy or false
 
 		local wrapped = function()
 			return fn(getters.by_name)
 		end
 
 		getters.by_name[name] = wrapped
-		table.insert(getters.items, { name = name, desc = desc, get = wrapped, enabled = enabled })
+		table.insert(getters.items, {
+			name = name,
+			desc = desc,
+			get = wrapped,
+			enabled = enabled,
+			lazy = lazy,
+		})
 	end
 end
 


### PR DESCRIPTION
- Add lsp.definition and lsp.references extras with lazy=true
- Lazy getters are evaluated on selection, not when picker opens
- Prevents UI blocking from LSP calls in large projects
- Add get_preview_text helper to DRY up picker display logic
- Add lsp config option (enabled, timeout) to config
- Fix deprecation warnings for make_position_params